### PR TITLE
PCI ATA+AHCI Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,14 @@ modules: libc snow ui
 doomgeneric: libc snow ui
 
 qemu: SnowflakeOS.iso
-	qemu-system-x86_64 -display gtk -cdrom SnowflakeOS.iso -monitor stdio -s -no-reboot -no-shutdown -serial file:serial.log
+	qemu-system-x86_64 -display gtk \
+	                   -drive file=SnowflakeOS.iso,id=disk,if=none \
+	                   -drive file=drive.img,id=test,if=none \
+			   -device ahci,id=ahci \
+			   -device ide-hd,drive=disk,bus=ahci.0,model=HOSTDEVICE,serial=10101010101 \
+			   -device ide-hd,drive=test,bus=ahci.1,model=TESTDRIVE,serial=6969696969696 \
+			   -monitor stdio \
+			   -s -no-reboot -no-shutdown -serial file:serial.log
 	cat serial.log
 
 bochs: SnowflakeOS.iso

--- a/drive.img
+++ b/drive.img
@@ -1,0 +1,1 @@
+SnowflakeOS SATA read support

--- a/kernel/include/kernel/ahci.h
+++ b/kernel/include/kernel/ahci.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <kernel/pci.h>
+
+
+typedef volatile struct hba_ghc_t {
+	uint32_t capabilities1;		// 0x00, Host capability
+	uint32_t ghc;			// 0x04, Global host control
+	uint32_t int_status;		// 0x08, Interrupt status
+	uint32_t ports_implemented;	// 0x0C, Port implemented
+	uint32_t version;		// 0x10, Version
+	uint32_t ccc_ctl;		// 0x14, Command completion coalescing control
+	uint32_t ccc_pts;		// 0x18, Command completion coalescing ports
+	uint32_t em_loc;		// 0x1C, Enclosure management location
+	uint32_t em_ctl;		// 0x20, Enclosure management control
+	uint32_t capabilities2;	 	// 0x24, Host capabilities extended
+	uint32_t bohc;			// 0x28, BIOS/OS handoff control and status
+}__attribute__((packed)) hba_ghc_t;
+
+typedef struct ahci_controller_t {
+	pci_device_t* pci_dev;
+	void* base_address;
+	void* base_address_virt;
+	uint32_t address_size;
+	volatile hba_ghc_t ghc;
+} ahci_controller_t;
+
+void init_ahci();
+void ahci_add_controller(pci_device_t* pci_dev);
+void init_controller(ahci_controller_t* controller);
+
+void ahci_print_controller(ahci_controller_t* controller);
+void ahci_print_all_controllers();

--- a/kernel/include/kernel/ahci.h
+++ b/kernel/include/kernel/ahci.h
@@ -2,27 +2,102 @@
 
 #include <kernel/pci.h>
 
+#define HBA_PORT_CMD_ST  (1 << 0)   // start processing the command list
+#define HBA_PORT_CMD_FRE (1 << 4)   // can post received FIS to fb pointer area
+#define HBA_PORT_CMD_FR  (1 << 14)  // indicates FIS engine is running
+#define HBA_PORT_CMD_CR  (1 << 15)  // indicates the command list engine is running
 
-typedef volatile struct hba_ghc_t {
-	uint32_t capabilities1;		// 0x00, Host capability
-	uint32_t ghc;			// 0x04, Global host control
-	uint32_t int_status;		// 0x08, Interrupt status
-	uint32_t ports_implemented;	// 0x0C, Port implemented
-	uint32_t version;		// 0x10, Version
-	uint32_t ccc_ctl;		// 0x14, Command completion coalescing control
-	uint32_t ccc_pts;		// 0x18, Command completion coalescing ports
-	uint32_t em_loc;		// 0x1C, Enclosure management location
-	uint32_t em_ctl;		// 0x20, Enclosure management control
-	uint32_t capabilities2;	 	// 0x24, Host capabilities extended
-	uint32_t bohc;			// 0x28, BIOS/OS handoff control and status
-}__attribute__((packed)) hba_ghc_t;
+#define HBA_CMDLIST_SIZE 0x400 // 1kb
+#define FIS_REC_SIZE 0x100 // 256b
+
+#define AHCI_ENABLE    (1<<31)
+#define AHCI_MAX_PORTS 32
+#define AHCI_PORTS_START_OFFSET 0x100
+#define AHCI_PORT_SIZE sizeof(HBA_port_t)
+
+#define	SATA_SIG_ATA	0x00000101	// SATA drive
+#define	SATA_SIG_ATAPI	0xEB140101	// SATAPI drive
+#define	SATA_SIG_SEMB	0xC33C0101	// Enclosure management bridge
+#define	SATA_SIG_PM	0x96690101	// Port multiplier
+
+
+// Generic host control
+typedef volatile struct HBA_ghc_t {
+    uint32_t cap1;     // 0x00, Host capability
+    uint32_t ghc;               // 0x04, Global host control
+    uint32_t int_status;        // 0x08, Interrupt status
+    uint32_t ports_implemented; // 0x0C, Port implemented
+    uint32_t version;           // 0x10, Version
+    uint32_t ccc_ctl;           // 0x14, Command completion coalescing control
+    uint32_t ccc_pts;           // 0x18, Command completion coalescing ports
+    uint32_t em_loc;            // 0x1C, Enclosure management location
+    uint32_t em_ctl;            // 0x20, Enclosure management control
+    uint32_t cap2;     // 0x24, Host capabilities extended
+    uint32_t bohc;              // 0x28, BIOS/OS handoff control and status
+} __attribute__((packed)) HBA_ghc_t;
+
+typedef volatile struct HBA_port_t {
+    uint32_t clb;       // 0x00, command list base address, 1K-byte aligned
+    uint32_t clbu;      // 0x04, command list base address upper 32 bits
+    uint32_t fb;        // 0x08, FIS base address, 256-byte aligned
+    uint32_t fbu;       // 0x0C, FIS base address upper 32 bits
+    uint32_t is;        // 0x10, interrupt status
+    uint32_t ie;        // 0x14, interrupt enable
+    uint32_t cmd;       // 0x18, command and status
+    uint32_t rsv0;      // 0x1C, Reserved
+    uint32_t tfd;       // 0x20, task file data
+    uint32_t sig;       // 0x24, signature
+    uint32_t ssts;      // 0x28, SATA status (SCR0:SStatus)
+    uint32_t sctl;      // 0x2C, SATA control (SCR2:SControl)
+    uint32_t serr;      // 0x30, SATA error (SCR1:SError)
+    uint32_t sact;      // 0x34, SATA active (SCR3:SActive)
+    uint32_t ci;        // 0x38, command issue
+    uint32_t sntf;      // 0x3C, SATA notification (SCR4:SNotification)
+    uint32_t fbs;       // 0x40, FIS-based switch control
+    uint32_t rsv1[11];  // 0x44 ~ 0x6F, Reserved
+    uint32_t vendor[4]; // 0x70 ~ 0x7F, vendor specific
+}__attribute__((packed)) HBA_port_t;
+
+typedef volatile struct HBA_cmd_hdr_t {
+    uint8_t cfl :  5;    // Command FIS length in DWORDS, 2 ~ 16
+    uint8_t a :    1;    // ATAPI
+    uint8_t w :    1;    // Write, 1: H2D, 0: D2H
+    uint8_t p :    1;    // Prefetchable
+    uint8_t r :    1;    // Reset
+    uint8_t b :    1;    // BIST
+    uint8_t c :    1;    // Clear busy upon R_OK
+    uint8_t rsv0 : 1;    // Reserved
+    uint8_t pmp :  4;    // Port multiplier port
+    uint16_t prdtl;      // Physical region descriptor table length in entries, 0 indicates don't process cmd
+    volatile uint32_t prdbc; // Physical region descriptor byte count transferred
+    uint32_t ctba;       // Command table descriptor base address
+    uint32_t ctbau;      // Command table descriptor base address upper 32 bits
+    uint32_t rsv1[4];    // Reserved
+}__attribute__((packed)) HBA_cmd_hdr_t;
+
+typedef volatile struct HBA_prdt_entry_t {
+    uint32_t dba;      // Data base address
+    uint32_t dbau;     // Data base address upper 32 bits
+    uint32_t rsv0;     // Reserved
+    uint32_t dbc: 22;  // Byte count, 4M max
+    uint32_t rsv1: 9;  // Reserved
+    uint32_t i: 1;     // Interrupt on completion
+}__attribute__((packed)) HBA_prdt_entry_t; // size is 0x10
+
+typedef volatile struct HBA_cmd_table_t { // must be 128 byte aligned
+    uint8_t cfis[64]; // Command FIS
+    uint8_t acmd[16]; // ATAPI command, 12 or 16 bytes
+    uint8_t rsv[48]; // Reserved
+    HBA_prdt_entry_t prdt_entry[1]; // Physical region descriptor table entries, 0 ~ 65535
+}__attribute__((packed)) HBA_cmd_table_t; // size is 0x80 + sizeof(HBA_pdtr_entry) = 0x90 total
 
 typedef struct ahci_controller_t {
-	pci_device_t* pci_dev;
-	void* base_address;
-	void* base_address_virt;
-	uint32_t address_size;
-	volatile hba_ghc_t ghc;
+    uint8_t id;
+    pci_device_t* pci_dev;
+    void* base_address;
+    void* base_address_virt;
+    uint32_t address_size;
+    HBA_ghc_t* ghc;
 } ahci_controller_t;
 
 void init_ahci();

--- a/kernel/include/kernel/ahci.h
+++ b/kernel/include/kernel/ahci.h
@@ -2,10 +2,15 @@
 
 #include <kernel/pci.h>
 
+#define AHCI_MAX_CONTROLLERS_NUM 256
+
 #define HBA_PORT_CMD_ST  (1 << 0)   // start processing the command list
 #define HBA_PORT_CMD_FRE (1 << 4)   // can post received FIS to fb pointer area
 #define HBA_PORT_CMD_FR  (1 << 14)  // indicates FIS engine is running
 #define HBA_PORT_CMD_CR  (1 << 15)  // indicates the command list engine is running
+
+#define HBA_PORT_IS_TFES (1 << 30)  // was there an error in the received fis
+
 
 #define HBA_CMDLIST_SIZE 0x400 // 1kb
 #define FIS_REC_SIZE 0x100 // 256b
@@ -15,10 +20,6 @@
 #define AHCI_PORTS_START_OFFSET 0x100
 #define AHCI_PORT_SIZE sizeof(HBA_port_t)
 
-#define	SATA_SIG_ATA	0x00000101	// SATA drive
-#define	SATA_SIG_ATAPI	0xEB140101	// SATAPI drive
-#define	SATA_SIG_SEMB	0xC33C0101	// Enclosure management bridge
-#define	SATA_SIG_PM	0x96690101	// Port multiplier
 
 
 // Generic host control
@@ -97,11 +98,10 @@ typedef struct ahci_controller_t {
     void* base_address;
     void* base_address_virt;
     uint32_t address_size;
-    HBA_ghc_t* ghc;
 } ahci_controller_t;
 
 void init_ahci();
-void ahci_add_controller(pci_device_t* pci_dev);
+bool ahci_add_controller(pci_device_t* pci_dev);
 void init_controller(ahci_controller_t* controller);
 
 void ahci_print_controller(ahci_controller_t* controller);

--- a/kernel/include/kernel/paging.h
+++ b/kernel/include/kernel/paging.h
@@ -16,7 +16,7 @@ uintptr_t paging_get_kernel_directory();
 page_t* paging_get_page(uintptr_t virt, bool create, uint32_t flags);
 void paging_map_page(uintptr_t virt, uintptr_t phys, uint32_t flags);
 void paging_unmap_page(uintptr_t virt);
-void paging_map_pages(uintptr_t phys, uintptr_t virt, uint32_t num, uint32_t flags);
+void paging_map_pages(uintptr_t virt, uintptr_t phys, uint32_t num, uint32_t flags);
 void paging_unmap_pages(uintptr_t virt, uint32_t num);
 void paging_switch_directory(uintptr_t dir_phys);
 void paging_invalidate_cache();
@@ -42,9 +42,12 @@ uintptr_t paging_virt_to_phys(uintptr_t virt);
 #define KERNEL_HEAP_BEGIN KERNEL_END_MAP
 #define KERNEL_HEAP_SIZE 0x1E00000
 
-#define PAGE_PRESENT 1
-#define PAGE_RW      2
-#define PAGE_USER    4
+#define PAGE_PRESENT          (1 << 0)
+#define PAGE_RW               (1 << 1)
+#define PAGE_USER             (1 << 2)
+#define PAGE_WT               (1 << 3)
+#define PAGE_CACHE_DISABLE    (1 << 4)
+
 #define PAGE_LARGE   128
 
 #define PAGE_FRAME   0xFFFFF000

--- a/kernel/include/kernel/pci.h
+++ b/kernel/include/kernel/pci.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <list.h>
 
+#define PCI_MAX_NUM_DEVS 256
+
 #define HDR0_BAR0 0x10
 #define HDR0_BAR1 0x14
 #define HDR0_BAR2 0x18
@@ -81,7 +83,7 @@ typedef volatile struct pci_device_t {
 
 
 void init_pci();
-uint32_t pci_read_config(uint8_t bus, uint8_t dev, uint8_t func, uint8_t* buf, uint32_t size);
+void pci_read_config(uint8_t bus, uint8_t dev, uint8_t func, uint8_t* buf, uint32_t size);
 
 uint16_t pci_read_config_word(uint8_t bus, uint8_t dev, uint8_t func, uint8_t offset);
 uint32_t pci_read_config_long(uint8_t bus, uint8_t dev, uint8_t func, uint8_t offset);

--- a/kernel/include/kernel/pci.h
+++ b/kernel/include/kernel/pci.h
@@ -3,14 +3,24 @@
 #include <stdint.h>
 #include <list.h>
 
-typedef struct pci_header_t {
+#define HDR0_BAR0 0x10
+#define HDR0_BAR1 0x14
+#define HDR0_BAR2 0x18
+#define HDR0_BAR3 0x1C
+#define HDR0_BAR4 0x20
+#define HDR0_BAR5 0x24
+
+#define MM_BAR_INFO_MASK 0x0000000F
+#define IO_BAR_INFO_MASK 0x00000003
+
+typedef volatile struct pci_header_t {
     uint16_t vendor, device;
     uint16_t command, status;
     uint8_t rev, interface, subclass, class;
     uint8_t cache_line_size, latency, header_type, bist;
 } __attribute__((packed)) pci_header_t;
 
-typedef struct pci_header0_t {
+typedef volatile struct pci_header0_t {
     uint32_t bar[6];
     uint32_t cardbus_cis_addr;
     uint16_t subsystem_vendor, subsystem;
@@ -22,7 +32,7 @@ typedef struct pci_header0_t {
 
 /* These are not useable right now: field must be reordered by groups of 4
  * bytes, reversed. */
-typedef struct pci_header1_t {
+typedef volatile struct pci_header1_t {
     uint32_t bar[2];
     uint8_t latency2, sub_bus, sec_bus, prim_bus;
     uint16_t secondary_status;
@@ -38,7 +48,7 @@ typedef struct pci_header1_t {
     uint8_t int_pin, int_line;
 } __attribute__((packed)) pci_header1_t;
 
-typedef struct pci_header2_t {
+typedef volatile struct pci_header2_t {
     uint32_t carbus_addr;
     uint16_t sec_status;
     uint8_t reserved, capabilities_offset;
@@ -57,7 +67,7 @@ typedef struct pci_header2_t {
     uint32_t legacy_base_addr;
 } __attribute__((packed)) pci_header2_t;
 
-typedef struct pci_device_t {
+typedef volatile struct pci_device_t {
     uint8_t id;
     uint8_t bus, dev, func;
     uint8_t hdr_type;
@@ -72,5 +82,9 @@ typedef struct pci_device_t {
 
 void init_pci();
 uint32_t pci_read_config(uint8_t bus, uint8_t dev, uint8_t func, uint8_t* buf, uint32_t size);
+
+uint16_t pci_read_config_word(uint8_t bus, uint8_t dev, uint8_t func, uint8_t offset);
+uint32_t pci_read_config_long(uint8_t bus, uint8_t dev, uint8_t func, uint8_t offset);
+void pci_write_config_long(uint8_t bus, uint8_t dev, uint8_t func, uint8_t offset, uint32_t data);
 void pci_print_device(pci_device_t* dev);
-void pci_print_all_devices(list_t *list);
+void pci_print_all_devices();

--- a/kernel/include/kernel/pci.h
+++ b/kernel/include/kernel/pci.h
@@ -10,7 +10,6 @@ typedef struct pci_header_t {
 } __attribute__((packed)) pci_header_t;
 
 typedef struct pci_header0_t {
-    pci_header_t header;
     uint32_t bar[6];
     uint32_t cardbus_cis_addr;
     uint16_t subsystem_vendor, subsystem;
@@ -20,8 +19,52 @@ typedef struct pci_header0_t {
     uint8_t int_line, int_pin, min_grant, max_latency;
 } __attribute__((packed)) pci_header0_t;
 
+/* These are not useable right now: field must be reordered by groups of 4
+ * bytes, reversed. */
+typedef struct pci_header1_t {
+    uint32_t bar[2];
+    uint8_t latency2, sub_bus, sec_bus, prim_bus;
+    uint16_t secondary_status;
+    uint8_t io_limit, io_base;
+    uint16_t memory_limit, memory_base;
+    uint16_t prefetch_limit, prefetch_base;
+    uint32_t prefetch_upper_limit, prefetch_upper_base;
+    uint16_t io_upper_limit, io_upper_base; // TODO use io_limit* prefixes
+    uint8_t reserved[3];
+    uint8_t capabilities_addr;
+    uint32_t expansion;
+    uint16_t bridge_control;
+    uint8_t int_pin, int_line;
+} __attribute__((packed)) pci_header1_t;
+
+typedef struct pci_header2_t {
+    uint32_t carbus_addr;
+    uint16_t sec_status;
+    uint8_t reserved, capabilities_offset;
+    uint8_t cardbus_latency, sub_bus, carbus_bus, pci_bus;
+    uint32_t mem_base_addr0;
+    uint32_t mem_limit0;
+    uint32_t mem_base_addr1;
+    uint32_t mem_limit1;
+    uint32_t io_base_addr0;
+    uint32_t io_limit0;
+    uint32_t io_base_addr1;
+    uint32_t io_limit1;
+    uint16_t bridge_control;
+    uint8_t int_pin, int_line;
+    uint16_t sub_vendor, sub_device;
+    uint32_t legacy_base_addr;
+} __attribute__((packed)) pci_header2_t;
+
 typedef struct pci_device_t {
+    uint8_t id;
     uint8_t bus, dev, func;
+    pci_header_t hdr;
+    union {
+        pci_header0_t header0;
+        pci_header1_t header1;
+        pci_header2_t header2;
+    };
 } pci_device_t;
 
 void init_pci();

--- a/kernel/include/kernel/pci.h
+++ b/kernel/include/kernel/pci.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <list.h>
 
 typedef struct pci_header_t {
     uint16_t vendor, device;
@@ -59,13 +60,17 @@ typedef struct pci_header2_t {
 typedef struct pci_device_t {
     uint8_t id;
     uint8_t bus, dev, func;
+    uint8_t hdr_type;
     pci_header_t hdr;
     union {
         pci_header0_t header0;
         pci_header1_t header1;
         pci_header2_t header2;
     };
-} pci_device_t;
+} __attribute__((packed)) pci_device_t;
+
 
 void init_pci();
 uint32_t pci_read_config(uint8_t bus, uint8_t dev, uint8_t func, uint8_t* buf, uint32_t size);
+void pci_print_device(pci_device_t* dev);
+void pci_print_all_devices(list_t *list);

--- a/kernel/include/kernel/sata.h
+++ b/kernel/include/kernel/sata.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <kernel/ahci.h>
+
+#define SATA_BLOCK_SIZE 512
+
+enum {
+    FIS_TYPE_REG_H2D   = 0x27, // Register FIS - host to device
+    FIS_TYPE_REG_D2H   = 0x34, // Register FIS - device to host
+    FIS_TYPE_DMA_ACT   = 0x39, // DMA activate FIS - device to host
+    FIS_TYPE_DMA_SETUP = 0x41, // DMA setup FIS - bidirectional
+    FIS_TYPE_DATA      = 0x46, // Data FIS - bidirectional
+    FIS_TYPE_BIST      = 0x58, // BIST activate FIS - bidirectional
+    FIS_TYPE_PIO_SETUP = 0x5F, // PIO setup FIS - device to host
+    FIS_TYPE_DEV_BITS  = 0xA1, // Set device bits FIS - device to host
+};
+
+enum {
+    ATA_CMD_IDENTIFY_DEV =     0xEC,
+    ATA_CMD_IDENTIFY_DEV_DMA = 0xEE,
+    ATA_CMD_READ_DMA_EXT =     0x25,
+    ATA_CMD_WRITE_DMA_EXT =    0x35,
+};
+
+enum {
+    SATA_DEV_SATA,
+    SATA_DEV_SATAPI,
+    SATA_DEV_SEMB,
+    SATA_DEV_PM,
+};
+
+typedef volatile struct FIS_reg_h2d_t {
+    uint8_t fis_type;   // FIS_TYPE_REG_H2D
+    uint8_t pmport : 4; // Port multiplier
+    uint8_t rsv0   : 3; // Reserved
+    uint8_t c      : 1; // 1: Command, 0: Control
+    uint8_t command;    // Command register
+    uint8_t featurel;   // Feature register, 7:0
+    uint8_t lba0;       // LBA low register, 7:0
+    uint8_t lba1;       // LBA mid register, 15:8
+    uint8_t lba2;       // LBA high register, 23:16
+    uint8_t device;     // Device register
+    uint8_t lba3;       // LBA register, 31:24
+    uint8_t lba4;       // LBA register, 39:32
+    uint8_t lba5;       // LBA register, 47:40
+    uint8_t featureh;   // Feature register, 15:8
+    uint8_t countl;     // Count register, 7:0
+    uint8_t counth;     // Count register, 15:8
+    uint8_t icc;        // Isochronous command completion
+    uint8_t control;    // Control register
+    uint8_t rsv1[4];    // Reserved
+} __attribute__((packed)) FIS_reg_h2d_t;
+
+typedef struct sata_device_t {
+    uint8_t id;
+    char model_name[20];
+    ahci_controller_t* controller;
+    uint8_t port_num;
+    uint32_t type;
+    void* cmdlist_base_virt;
+    void* fis_rec_virt;
+    HBA_cmd_table_t* cmd_table_virt;
+    void* data_base_virt;
+} sata_device_t;
+
+
+void sata_add_device(ahci_controller_t* c, uint32_t port, uint32_t type);
+void sata_setup_memory(sata_device_t* dev);
+void sata_send_command(sata_device_t* dev);
+void sata_identify_device(sata_device_t* dev);
+void sata_read(sata_device_t* dev);
+void sata_write(sata_device_t* dev);

--- a/kernel/src/devices/ahci.c
+++ b/kernel/src/devices/ahci.c
@@ -6,8 +6,11 @@
 #include <stdlib.h>
 #include <kernel/paging.h>
 #include <string.h>
+#include <kernel/sata.h>
+
 
 static list_t ahci_controllers;
+static uint8_t next_dev_id = 0;
 static bool list_inited = false;
 
 void init_ahci() {
@@ -22,87 +25,103 @@ void ahci_add_controller(pci_device_t* pci_dev) {
     }
 
     ahci_controller_t* controller = (ahci_controller_t*)kmalloc(sizeof(ahci_controller_t));
+    controller->id = next_dev_id;
+    next_dev_id++;
     controller->pci_dev = pci_dev;
     init_controller(controller);
     if(!list_add(&ahci_controllers, (void*)controller)) {
         printke("unable to add ahci controller");
+	kfree(controller);
     }
 }
 
 void init_controller(ahci_controller_t* controller) {
     // get BAR size
-	uint32_t bar5, size;
-	bar5 = pci_read_config_long(controller->pci_dev->bus,
-                                controller->pci_dev->dev,
-                                controller->pci_dev->func,
-                                HDR0_BAR5);
+    uint32_t bar5, size;
+    bar5 = controller->pci_dev->header0.bar[5];
 
-    bar5 &= ~MM_BAR_INFO_MASK; // mask off the information bits
-	
-	pci_write_config_long(controller->pci_dev->bus,
-	                      controller->pci_dev->dev,
-                          controller->pci_dev->func,
-                          HDR0_BAR5,0xFFFFFFFF); // all ones to indicate get address size
-	
-	size = pci_read_config_long(controller->pci_dev->bus,
-                                controller->pci_dev->dev,
-                                controller->pci_dev->func,
-                                HDR0_BAR5);
-    
+    // write all 1s to indicate get address size
+    pci_write_config_long(controller->pci_dev->bus, controller->pci_dev->dev,
+        controller->pci_dev->func, HDR0_BAR5, 0xFFFFFFFF);
+
+    // read back the value
+    size = pci_read_config_long(
+        controller->pci_dev->bus, controller->pci_dev->dev, controller->pci_dev->func, HDR0_BAR5);
+
+    // calculation to get size
     size &= ~MM_BAR_INFO_MASK; // mask information bits
-    size = ~size;       // invert
+    size = ~size;              // invert
     size += 1;
 
+    // reset bar
+    pci_write_config_long(controller->pci_dev->bus, controller->pci_dev->dev,
+        controller->pci_dev->func, HDR0_BAR5, bar5);
 
-	// reset bar
-	pci_write_config_long(controller->pci_dev->bus,
-	                      controller->pci_dev->dev,
-                          controller->pci_dev->func,
-                          HDR0_BAR5,bar5);
-	
-    controller->base_address = (void*)bar5;
-	controller->address_size = size;
-
+    bar5 &= ~MM_BAR_INFO_MASK; // mask off the information bits
+    controller->base_address = (void*) bar5;
+    controller->address_size = size;
 
     ///// map base address into virtual memory - mark as do not cache because phys addr is hardware
     uint32_t num_pages = controller->address_size / 0x1000;
-    if(controller->address_size % 0x1000 != 0)
-        num_pages++;
+    if (controller->address_size % 0x1000 != 0)
+        num_pages++; // grab the remaining bottom page if the required memory isn't paged aligned
 
     // NOTE: not sure how best to implement getting free virtual
     // memory in kernel space that can be mapped to hardware
-    void* virt = kamalloc(0x1000, num_pages*0x1000);
-    paging_unmap_pages((uintptr_t)virt,num_pages);
+    void* virt = kamalloc(0x1000, num_pages * 0x1000);
+    paging_unmap_pages((uintptr_t) virt, num_pages);
 
-    paging_map_pages((uintptr_t)virt, (uintptr_t)controller->base_address, num_pages, 1<<PAGE_CACHE_DISABLE);
+    paging_map_pages((uintptr_t) virt, (uintptr_t) controller->base_address, num_pages, PAGE_CACHE_DISABLE);
 
     controller->base_address_virt = virt;
+    controller->ghc = controller->base_address_virt;
 
-    /////  copy in ghc
-    memcpy(&controller->ghc,controller->base_address_virt,sizeof(hba_ghc_t));
+    // mark that ahci mode is enabled / notify the controller we are going to use it
+    controller->ghc->ghc |= AHCI_ENABLE;
+
+
+    // check devices on available ports
+    for(int i = 0; i < AHCI_MAX_PORTS; i++){
+        if(!((controller->ghc->ports_implemented >> i) & 0x01))
+            continue;
+
+        // check port device status and type
+        HBA_port_t *port = (HBA_port_t*)(controller->base_address_virt + AHCI_PORTS_START_OFFSET + i*AHCI_PORT_SIZE);
+            
+        if((port->ssts & 0xF) == 0x03) { // device present and connection established
+
+            uint32_t device_type = port->sig;
+            switch(device_type) {
+            case SATA_SIG_ATA:
+                sata_add_device(controller, i, SATA_DEV_SATA);
+                break;
+            case SATA_SIG_ATAPI:
+                sata_add_device(controller, i, SATA_DEV_SATAPI);
+                break;
+            case SATA_SIG_SEMB:
+                sata_add_device(controller, i, SATA_DEV_SEMB);
+                break;
+            case SATA_SIG_PM:
+                sata_add_device(controller, i, SATA_DEV_PM);
+                break;
+            default:
+                printk("couldn't determine sata device type, provided type was: 0x%x", device_type);
+                break;
+            }
+        }
+    }
 
 }
 
 void ahci_print_controller(ahci_controller_t* controller) {
-    printk("ahci controller with pci id: %d, BAR: 0x%x, BAR virt: 0x%x, "
-            "BAR size: 0x%x, version: 0x%x",
-           controller->pci_dev->id, controller->base_address, controller->base_address_virt,
-           controller->address_size, controller->ghc.version);
+    printk("ahci controller with id: %d, pci id: %d, BAR: 0x%x, BAR virt: 0x%x, "
+           "BAR size: 0x%x, version: 0x%x, capabilities: 0x%x",
+        controller->id, controller->pci_dev->id, controller->base_address, controller->base_address_virt,
+        controller->address_size, controller->ghc->version, controller->ghc->cap1);
+
+    printk(" - %d control slots per port", (controller->ghc->cap1 >> 8) & 0b1111);
 
 
-    // print number of ports
-    char ports_str[1024] = {0};
-    unsigned int i;
-    for(i = 0; i < sizeof(controller->ghc.ports_implemented)*8;i++) {
-        if(((controller->ghc.ports_implemented>>i) & 0x01) == true) {
-            char tmp[3] = {0};
-            sprintf(tmp,"%d,", i);
-            strcat(ports_str,tmp);
-        }
-    }
-
-    ports_str[strlen(ports_str)-1] = 0;
-    printk(" - ports implemented: %s",ports_str);
 }
 
 void ahci_print_all_controllers() {

--- a/kernel/src/devices/ahci.c
+++ b/kernel/src/devices/ahci.c
@@ -1,0 +1,113 @@
+#include <kernel/ahci.h>
+
+#include <kernel/pci.h>
+#include <kernel/sys.h>
+#include <list.h>
+#include <stdlib.h>
+#include <kernel/paging.h>
+#include <string.h>
+
+static list_t ahci_controllers;
+static bool list_inited = false;
+
+void init_ahci() {
+    printk("initalizing ahci");
+    ahci_print_all_controllers();
+}
+
+void ahci_add_controller(pci_device_t* pci_dev) {
+    if(!list_inited) {
+        ahci_controllers = LIST_HEAD_INIT(ahci_controllers);
+        list_inited = true;
+    }
+
+    ahci_controller_t* controller = (ahci_controller_t*)kmalloc(sizeof(ahci_controller_t));
+    controller->pci_dev = pci_dev;
+    init_controller(controller);
+    if(!list_add(&ahci_controllers, (void*)controller)) {
+        printke("unable to add ahci controller");
+    }
+}
+
+void init_controller(ahci_controller_t* controller) {
+    // get BAR size
+	uint32_t bar5, size;
+	bar5 = pci_read_config_long(controller->pci_dev->bus,
+                                controller->pci_dev->dev,
+                                controller->pci_dev->func,
+                                HDR0_BAR5);
+
+    bar5 &= ~MM_BAR_INFO_MASK; // mask off the information bits
+	
+	pci_write_config_long(controller->pci_dev->bus,
+	                      controller->pci_dev->dev,
+                          controller->pci_dev->func,
+                          HDR0_BAR5,0xFFFFFFFF); // all ones to indicate get address size
+	
+	size = pci_read_config_long(controller->pci_dev->bus,
+                                controller->pci_dev->dev,
+                                controller->pci_dev->func,
+                                HDR0_BAR5);
+    
+    size &= ~MM_BAR_INFO_MASK; // mask information bits
+    size = ~size;       // invert
+    size += 1;
+
+
+	// reset bar
+	pci_write_config_long(controller->pci_dev->bus,
+	                      controller->pci_dev->dev,
+                          controller->pci_dev->func,
+                          HDR0_BAR5,bar5);
+	
+    controller->base_address = (void*)bar5;
+	controller->address_size = size;
+
+
+    ///// map base address into virtual memory - mark as do not cache because phys addr is hardware
+    uint32_t num_pages = controller->address_size / 0x1000;
+    if(controller->address_size % 0x1000 != 0)
+        num_pages++;
+
+    // NOTE: not sure how best to implement getting free virtual
+    // memory in kernel space that can be mapped to hardware
+    void* virt = kamalloc(0x1000, num_pages*0x1000);
+    paging_unmap_pages((uintptr_t)virt,num_pages);
+
+    paging_map_pages((uintptr_t)virt, (uintptr_t)controller->base_address, num_pages, 1<<PAGE_CACHE_DISABLE);
+
+    controller->base_address_virt = virt;
+
+    /////  copy in ghc
+    memcpy(&controller->ghc,controller->base_address_virt,sizeof(hba_ghc_t));
+
+}
+
+void ahci_print_controller(ahci_controller_t* controller) {
+    printk("ahci controller with pci id: %d, BAR: 0x%x, BAR virt: 0x%x, "
+            "BAR size: 0x%x, version: 0x%x",
+           controller->pci_dev->id, controller->base_address, controller->base_address_virt,
+           controller->address_size, controller->ghc.version);
+
+
+    // print number of ports
+    char ports_str[1024] = {0};
+    unsigned int i;
+    for(i = 0; i < sizeof(controller->ghc.ports_implemented)*8;i++) {
+        if(((controller->ghc.ports_implemented>>i) & 0x01) == true) {
+            char tmp[3] = {0};
+            sprintf(tmp,"%d,", i);
+            strcat(ports_str,tmp);
+        }
+    }
+
+    ports_str[strlen(ports_str)-1] = 0;
+    printk(" - ports implemented: %s",ports_str);
+}
+
+void ahci_print_all_controllers() {
+    ahci_controller_t* c;
+    list_for_each_entry(c, &ahci_controllers) {
+        ahci_print_controller(c);
+    }
+}

--- a/kernel/src/devices/ide.c
+++ b/kernel/src/devices/ide.c
@@ -1,7 +1,6 @@
 #include <kernel/ide.h>
+#include <kernel/pci.h>
 
 void init_ide(pci_device_t dev) {
-    pci_header0_t hdr;
-
-    pci_read_config(dev.bus, dev.dev, dev.func, (uint8_t*) &hdr, sizeof(hdr));
+    return;
 }

--- a/kernel/src/devices/pci.c
+++ b/kernel/src/devices/pci.c
@@ -1,5 +1,6 @@
 #include <kernel/com.h>
 #include <kernel/pci.h>
+#include <kernel/ahci.h>
 #include <kernel/sys.h>
 #include <stdlib.h>
 #include <list.h>
@@ -30,6 +31,23 @@ uint16_t pci_read_config_word(uint8_t bus, uint8_t dev, uint8_t func, uint8_t of
     }
 
     return (uint16_t) out;
+}
+
+uint32_t pci_read_config_long(uint8_t bus, uint8_t dev, uint8_t func, uint8_t offset) {
+    uint32_t addr = (offset & ~3) | func << 8 | dev << 11 | bus << 16 | CFG_ENABLE;
+
+    outportl(CFG_ADDR, addr);
+    uint32_t out = inportl(CFG_DATA);
+
+    return out;
+}
+
+void pci_write_config_long(uint8_t bus, uint8_t dev, uint8_t func, uint8_t offset, uint32_t data) {
+    uint32_t addr = (offset & ~3) | func << 8 | dev << 11 | bus << 16 | CFG_ENABLE;
+
+    outportl(CFG_ADDR, addr);
+    outportl(CFG_DATA, data);
+
 }
 
 bool pci_bus_has_device(uint8_t bus, uint8_t dev) {
@@ -68,9 +86,9 @@ void pci_print_device(pci_device_t* dev) {
     }
 }
 
-void pci_print_all_devices(list_t *list) {
+void pci_print_all_devices() {
     pci_device_t* dev;
-    list_for_each_entry(dev, list) {
+    list_for_each_entry(dev, &pci_devices) {
         pci_print_device(dev);
     }
 }
@@ -112,13 +130,15 @@ pci_device_t * pci_register_device(uint32_t bus, uint32_t dev, uint32_t func) {
         return NULL;
     }
 
-    list_add(&pci_devices, device);
+    if(!list_add(&pci_devices, device)) {
+        printke("unable to add pci device");
+    }
 
     /* AHCI controller */
     if (device->hdr.class == 0x01 &&
         device->hdr.subclass == 0x06 &&
         device->hdr.interface == 0x01) {
-
+            ahci_add_controller(device);
     }
 
     return device;
@@ -164,7 +184,8 @@ uint32_t pci_read_config(uint8_t bus, uint8_t dev, uint8_t func, uint8_t* buf, u
 }
 
 void init_pci() {
+    printk("Initializing PCI");
     pci_devices = LIST_HEAD_INIT(pci_devices);
     pci_enumerate_devices();
-    pci_print_all_devices(&pci_devices);
+    pci_print_all_devices();
 }

--- a/kernel/src/devices/pci.c
+++ b/kernel/src/devices/pci.c
@@ -132,6 +132,8 @@ pci_device_t * pci_register_device(uint32_t bus, uint32_t dev, uint32_t func) {
 
     if(!list_add(&pci_devices, device)) {
         printke("unable to add pci device");
+	kfree(device);
+	return NULL;
     }
 
     /* AHCI controller */

--- a/kernel/src/devices/pci.c
+++ b/kernel/src/devices/pci.c
@@ -95,8 +95,18 @@ void pci_print_all_devices() {
 
 
 pci_device_t * pci_register_device(uint32_t bus, uint32_t dev, uint32_t func) {
+    if(next_dev_id >= PCI_MAX_NUM_DEVS) {
+        printke("Trying to register a PCI device with no spots left");
+        return NULL;
+    }
+
     pci_device_t *device = (pci_device_t *)kmalloc(sizeof(pci_device_t));
-    // TODO: check for device id overflow
+    if(!device){
+        printke("unable to allocate space for a PCI device bus: %d, dev: %d, func: %d", bus, dev, func);
+        return NULL;
+    }
+
+
     device->id = next_dev_id;
     next_dev_id++;
 
@@ -107,8 +117,6 @@ pci_device_t * pci_register_device(uint32_t bus, uint32_t dev, uint32_t func) {
     device->hdr_type = pci_header_type(bus,dev) & ~HEADER_MULTIFUNC;
 
 
-    // TODO: change this, make read config take a header type and populate both headers
-    // then you can also unpack the pci_device struct
     uint32_t size;
     switch (device->hdr_type)
     {
@@ -124,14 +132,13 @@ pci_device_t * pci_register_device(uint32_t bus, uint32_t dev, uint32_t func) {
         size = sizeof(device->hdr) + sizeof(device->header2);
         pci_read_config(bus, dev, func, (uint8_t*)&device->hdr, size);
         break;
-    
     default:
         printke("error with pci header type. Value provided: %d", device->hdr_type);
         return NULL;
     }
 
     if(!list_add(&pci_devices, device)) {
-        printke("unable to add pci device");
+        printke("unable to add pci device to list");
 	kfree(device);
 	return NULL;
     }
@@ -161,28 +168,23 @@ void pci_enumerate_devices() {
                         continue;
                     }
 
-                    if(!pci_register_device(bus,dev,func)) {
-                        printke("error registering device");
-                    }
-
+                    if (!pci_register_device(bus, dev, func))
+                        printke("error registering device bus: %d, dev: %d, func: %d", bus, dev, func);
                 }
             } else {
-                if(!pci_register_device(bus, dev,0)) {
-                    printke("error registering device");
-                }
+                if (!pci_register_device(bus, dev, 0))
+                    printke("error registering device bus: %d, dev: %d, func: %d", bus, dev, 0);
             }
-
         }
     }
 }
 
-uint32_t pci_read_config(uint8_t bus, uint8_t dev, uint8_t func, uint8_t* buf, uint32_t size) {
+void pci_read_config(uint8_t bus, uint8_t dev, uint8_t func, uint8_t* buf, uint32_t size) {
     for(uint32_t i = 0; i < size; i+=2) {
         uint16_t word = pci_read_config_word(bus,dev,func,i);
         buf[i + 0] = (uint8_t)(word & 0x00FF);
         buf[i + 1] = (uint8_t)(word >> 8);
     }
-    return 0;
 }
 
 void init_pci() {

--- a/kernel/src/devices/sata.c
+++ b/kernel/src/devices/sata.c
@@ -165,7 +165,15 @@ bool sata_identify_device(sata_device_t* dev) {
     port->ci = 0x01;
 
     // wait for port to return that the command has finished without error
-    while(port->ci != 0x0);
+    uint32_t spin = 0;
+    while(port->ci != 0x0){
+        spin++;
+        if(spin > 10000) {
+            printk("Port appears to be stuck during device identification for sata dev: %d", dev->id);
+            return false;
+        }
+    }
+
     if(port->is & HBA_PORT_IS_TFES) {
         printk("error identifying device %d", dev->id);
         return false;
@@ -231,7 +239,14 @@ bool sata_read_device(sata_device_t* dev, uint32_t block_num_l, uint16_t block_n
     port->ci = 0x01;
 
     // wait for port to return that the command has finished
-    while(port->ci != 0x0);
+    uint32_t spin = 0;
+    while(port->ci != 0x0){
+        spin++;
+        if(spin > 10000) {
+            printk("Port appears to be stuck during read for sata dev: %d", dev->id);
+            return false;
+        }
+    }
 
     if(port->is & (1<<30)) {
         printke("Error attempting to read from sata device id: %d", dev->id);
@@ -275,7 +290,14 @@ bool sata_write_device(sata_device_t* dev, uint32_t block_num_l, uint16_t block_
     port->ci = 0x01;
 
     // wait for port to return that the command has finished
-    while(port->ci != 0x0);
+    uint32_t spin = 0;
+    while(port->ci != 0x0){
+        spin++;
+        if(spin > 10000) {
+            printk("Port appears to be stuck during write for sata dev: %d", dev->id);
+            return false;
+        }
+    }
 
     if(port->is & (1<<30)) {
         printke("Error attempting to write to sata device id: %d", dev->id);

--- a/kernel/src/devices/sata.c
+++ b/kernel/src/devices/sata.c
@@ -6,18 +6,28 @@
 #include <kernel/paging.h>
 
 static list_t sata_devs;
-static uint8_t next_dev_id = 0;
+static uint32_t next_dev_id = 0;
 static bool list_inited = false;
 
-
-
-void sata_add_device(ahci_controller_t* c, uint32_t port, uint32_t type) {
+bool sata_add_device(ahci_controller_t* c, uint32_t port, uint32_t type) {
     if(!list_inited) {
         sata_devs = LIST_HEAD_INIT(sata_devs);
         list_inited = true;
     }
 
+    if(next_dev_id >= SATA_MAX_DEVS) {
+        printk("trying to add a sata device with no slots left");
+        return false;
+    }
+
     sata_device_t* dev = (sata_device_t*)kmalloc(sizeof(sata_device_t));
+    if(!dev) {
+        printke("error allocating space for sata device on ahci controller: %d, port: %d",
+                c->id, port);
+        return false;
+    }
+
+
     dev->id = next_dev_id;
     next_dev_id++;
     dev->controller = c;
@@ -25,18 +35,25 @@ void sata_add_device(ahci_controller_t* c, uint32_t port, uint32_t type) {
     dev->type = type;
 
     if(!list_add(&sata_devs, (void*)dev)) {
-        printke("unable to add sata dev");
+        printke("unable to add sata dev to list");
 	kfree(dev);
     }
 
     sata_setup_memory(dev);
     sata_identify_device(dev);
 
+    // uncomment below to do a read of the first sector of each drive
+    /* uint8_t* buf = kmalloc(SATA_BLOCK_SIZE); */
+    /* memset(buf,0,SATA_BLOCK_SIZE); */
+    /* sata_read_device(dev,0,0,buf); */
+    /* printk("read from sata device %d: %s", dev->id,buf); */
+
+    return true;
 }
 
 // at this point in time we will only allow one command at a time,
 // no adding multiple commands to the command list. And only r/w one sector at a time
-void sata_setup_memory(sata_device_t* dev) {
+bool sata_setup_memory(sata_device_t* dev) {
     HBA_port_t* port = (dev->controller->base_address_virt + AHCI_PORTS_START_OFFSET + dev->port_num*AHCI_PORT_SIZE);
     //// make sure the port isn't running
     port->cmd &= ~HBA_PORT_CMD_ST;  // indicate to not process command list
@@ -59,16 +76,24 @@ void sata_setup_memory(sata_device_t* dev) {
     // if its greater than a page, we have an issue
     if (size > 0x1000) {
         printke("Issue setting up sata device id: %d, memory space larger than a page", dev->id);
-        return;
+        return false;;
     }
 
     void* cmdlist_base = kamalloc(size, 0x1000);
+    if(!cmdlist_base) {
+        printke("error allocating virt mem for sata dev id: %d cmdlist base", dev->id);
+        return false;
+    }
     // mark page as cache disable
     page_t *page = paging_get_page((uintptr_t)cmdlist_base, false, 0);
     *page |= PAGE_CACHE_DISABLE;
 
     // set command list base
     uint32_t cmdlist_phys_base = (uint32_t)paging_virt_to_phys((uintptr_t)cmdlist_base);
+    if(!cmdlist_phys_base) {
+        printke("error getting physical memory location for sata dev id: %d cmdlist base", dev->id);
+        return false;
+    }
     port->clb = cmdlist_phys_base;
     port->clbu = 0;
 
@@ -77,17 +102,17 @@ void sata_setup_memory(sata_device_t* dev) {
     port->fbu = 0;
 
     // check alignments
-    if(cmdlist_phys_base & 0b1111111111) {
+    if(cmdlist_phys_base & 0b1111111111) { // 1k align
         printke("Issue setting up sata device id: %d, cmdlist not aligned", dev->id);
-        return;
+        return false;
     }
-    if((cmdlist_phys_base+HBA_CMDLIST_SIZE) & 0b11111111) {
+    if((cmdlist_phys_base+HBA_CMDLIST_SIZE) & 0b11111111) { // 256 align
         printke("Issue setting up sata device id: %d, fis receive not aligned", dev->id);
-        return;
+        return false;
     }
-    if((cmdlist_phys_base+HBA_CMDLIST_SIZE+FIS_REC_SIZE) & 0b1111111) {
+    if((cmdlist_phys_base+HBA_CMDLIST_SIZE+FIS_REC_SIZE) & 0b1111111) { // 128 align
         printke("Issue setting up sata device id: %d, cmdtbl not aligned", dev->id);
-        return;
+        return false;
     }
 
     //// zero out memory space and then appropriately fill the data structures
@@ -106,31 +131,26 @@ void sata_setup_memory(sata_device_t* dev) {
     tbl->prdt_entry[0].dbc = SATA_BLOCK_SIZE;
 
     //// allow port to start running again
-    while (port->cmd & HBA_PORT_CMD_CR); // make sure port isn't running
+    while (port->cmd & HBA_PORT_CMD_CR); // make sure port isn't running, not sure why this is needed we already indicated the port shouldn't start
 
     port->cmd |= HBA_PORT_CMD_FRE; // indicate it can post to FIS
     port->cmd |= HBA_PORT_CMD_ST;  // indicate to start processing command list
-
-
 
     //// store virtual addresses in device struct
     dev->cmdlist_base_virt = cmdlist_base;
     dev->fis_rec_virt = cmdlist_base + (HBA_CMDLIST_SIZE);
     dev->cmd_table_virt = cmdlist_base + (HBA_CMDLIST_SIZE + FIS_REC_SIZE);
     dev->data_base_virt = cmdlist_base + (HBA_CMDLIST_SIZE + FIS_REC_SIZE + sizeof(HBA_cmd_table_t));
+
+    return true;
 }
-
-
-void sata_send_command(sata_device_t* dev) {
-    return;
-}
-
 
 // send identify device command
-void sata_identify_device(sata_device_t* dev) {
+bool sata_identify_device(sata_device_t* dev) {
     HBA_port_t* port = (dev->controller->base_address_virt + AHCI_PORTS_START_OFFSET + dev->port_num*AHCI_PORT_SIZE);
 
     HBA_cmd_hdr_t* hdr = (HBA_cmd_hdr_t*)dev->cmdlist_base_virt;
+    hdr->cfl = sizeof(FIS_reg_h2d_t)/sizeof(uint32_t);
     HBA_cmd_table_t* tbl = dev->cmd_table_virt;
 
     FIS_reg_h2d_t cmd = {0};
@@ -138,35 +158,130 @@ void sata_identify_device(sata_device_t* dev) {
     cmd.c = 1;
     cmd.command = ATA_CMD_IDENTIFY_DEV;
 
-
+    // move command to 
     memcpy(tbl,&cmd,sizeof(cmd));
 
+    // issue command
     port->ci = 0x01;
 
-    // spin for a second
-    for(int i = 0; i < 1000000; i++);
-
-
-    char* ptr = dev->data_base_virt;
-
-    printk("DEV IDENT response: ");
-    for(int i = 0; i < 512; i++) {
-        printk(" - %c",ptr[i]);
+    // wait for port to return that the command has finished without error
+    while(port->ci != 0x0);
+    if(port->is & HBA_PORT_IS_TFES) {
+        printk("error identifying device %d", dev->id);
+        return false;
     }
 
-    return;
+    char* dest = dev->model_name;
+    char* src = dev->data_base_virt+SATA_DEV_MODEL_OFFSET;
+
+    // copy name to device struct, swap bits due to sata endianess
+    for(unsigned int i = 0; i < sizeof(dev->model_name);i+=2){
+        dest[i] = src[i+1];
+        dest[i+1] = src[i];
+
+        if(src[i] < 0x21 || src[i] > 0x7E) // not a printable character
+            dest[i+1] = 0;
+        if(src[i+1] < 0x21 || src[i+1] > 0x7E) // not a printable character
+            dest[i] = 0;
+
+    }
+
+    uint16_t* base = (uint16_t*)dev->data_base_virt;
+
+    uint32_t capacity;
+    capacity = base[SATA_DEV_LBA_CAP_OFFSET/2];
+    capacity |= (((uint32_t)base[SATA_DEV_LBA_CAP_OFFSET/2+1]) << 16);
+
+    dev->capacity_in_sectors = capacity;
+
+    printk("Identified SATA Device of type 0x%x with name: %s and capacity: 0x%x blocks",
+           dev->type, dev->model_name, dev->capacity_in_sectors);
+
+    return true;
 }
 
-void sata_read(sata_device_t* dev) {
-    return;
-}
 
-void sata_write(sata_device_t* dev) {
-    return;
-}
-
-void sata_read_device(sata_device_t* dev, uint32_t startl, uint32_t starth, uint32_t count, uint8_t *buf) {
+bool sata_read_device(sata_device_t* dev, uint32_t block_num_l, uint16_t block_num_h, uint8_t *buf){
     //// send read command
-    // 
-    return;
+    HBA_port_t* port = (dev->controller->base_address_virt + AHCI_PORTS_START_OFFSET + dev->port_num*AHCI_PORT_SIZE);
+
+    HBA_cmd_hdr_t* hdr = (HBA_cmd_hdr_t*)dev->cmdlist_base_virt;
+    hdr->cfl = sizeof(FIS_reg_h2d_t)/sizeof(uint32_t);
+    hdr->c = 1;
+    HBA_cmd_table_t* tbl = dev->cmd_table_virt;
+
+    FIS_reg_h2d_t cmd = {0};
+    cmd.fis_type = FIS_TYPE_REG_H2D;
+    cmd.c = 1;
+    cmd.command = ATA_CMD_READ_DMA_EXT;
+    cmd.countl = 1;
+    cmd.device = (1<<6); // lba48 mode?
+
+    cmd.lba0 = (block_num_l >> 0) & 0xFF;
+    cmd.lba1 = (block_num_l >> 8) & 0xFF;
+    cmd.lba2 = (block_num_l >> 16) & 0xFF;
+    cmd.lba3 = (block_num_l >> 24) & 0xFF;
+    cmd.lba4 = (block_num_h >> 0) & 0xFF;
+    cmd.lba5 = (block_num_h >> 8) & 0xFF;
+
+    // move command to table
+    memcpy(tbl,&cmd,sizeof(cmd));
+
+    // issue command
+    port->ci = 0x01;
+
+    // wait for port to return that the command has finished
+    while(port->ci != 0x0);
+
+    if(port->is & (1<<30)) {
+        printke("Error attempting to read from sata device id: %d", dev->id);
+        return false;
+    }
+
+    memcpy(buf, dev->data_base_virt, SATA_BLOCK_SIZE);
+
+    return true;
+}
+
+bool sata_write_device(sata_device_t* dev, uint32_t block_num_l, uint16_t block_num_h, uint8_t *buf){
+    //// send read command
+    HBA_port_t* port = (dev->controller->base_address_virt + AHCI_PORTS_START_OFFSET + dev->port_num*AHCI_PORT_SIZE);
+
+    HBA_cmd_hdr_t* hdr = (HBA_cmd_hdr_t*)dev->cmdlist_base_virt;
+    hdr->cfl = sizeof(FIS_reg_h2d_t)/sizeof(uint32_t);
+    hdr->c = 1;
+    HBA_cmd_table_t* tbl = dev->cmd_table_virt;
+
+    FIS_reg_h2d_t cmd = {0};
+    cmd.fis_type = FIS_TYPE_REG_H2D;
+    cmd.c = 1;
+    cmd.command = ATA_CMD_WRITE_DMA_EXT;
+    cmd.countl = 1;
+    cmd.device = (1<<6); // lba48 mode?
+
+    cmd.lba0 = (block_num_l >> 0) & 0xFF;
+    cmd.lba1 = (block_num_l >> 8) & 0xFF;
+    cmd.lba2 = (block_num_l >> 16) & 0xFF;
+    cmd.lba3 = (block_num_l >> 24) & 0xFF;
+    cmd.lba4 = (block_num_h >> 0) & 0xFF;
+    cmd.lba5 = (block_num_h >> 8) & 0xFF;
+
+    memcpy(dev->data_base_virt, buf, SATA_BLOCK_SIZE);
+
+    // move command to table
+    memcpy(tbl,&cmd,sizeof(cmd));
+
+    // issue command
+    port->ci = 0x01;
+
+    // wait for port to return that the command has finished
+    while(port->ci != 0x0);
+
+    if(port->is & (1<<30)) {
+        printke("Error attempting to write to sata device id: %d", dev->id);
+        return false;
+    }
+
+
+    return true;
 }

--- a/kernel/src/devices/sata.c
+++ b/kernel/src/devices/sata.c
@@ -1,0 +1,172 @@
+#include <kernel/sata.h>
+
+#include <list.h>
+#include <stdlib.h>
+#include <kernel/sys.h>
+#include <kernel/paging.h>
+
+static list_t sata_devs;
+static uint8_t next_dev_id = 0;
+static bool list_inited = false;
+
+
+
+void sata_add_device(ahci_controller_t* c, uint32_t port, uint32_t type) {
+    if(!list_inited) {
+        sata_devs = LIST_HEAD_INIT(sata_devs);
+        list_inited = true;
+    }
+
+    sata_device_t* dev = (sata_device_t*)kmalloc(sizeof(sata_device_t));
+    dev->id = next_dev_id;
+    next_dev_id++;
+    dev->controller = c;
+    dev->port_num = port;
+    dev->type = type;
+
+    if(!list_add(&sata_devs, (void*)dev)) {
+        printke("unable to add sata dev");
+	kfree(dev);
+    }
+
+    sata_setup_memory(dev);
+    sata_identify_device(dev);
+
+}
+
+// at this point in time we will only allow one command at a time,
+// no adding multiple commands to the command list. And only r/w one sector at a time
+void sata_setup_memory(sata_device_t* dev) {
+    HBA_port_t* port = (dev->controller->base_address_virt + AHCI_PORTS_START_OFFSET + dev->port_num*AHCI_PORT_SIZE);
+    //// make sure the port isn't running
+    port->cmd &= ~HBA_PORT_CMD_ST;  // indicate to not process command list
+    port->cmd &= ~HBA_PORT_CMD_FRE; // indicate to not post to FIS received area
+
+    // wait for the FIS and command list engine to complete
+    while (1) {
+        if (port->cmd & HBA_PORT_CMD_FR)
+            continue;
+        if (port->cmd & HBA_PORT_CMD_CR)
+            continue;
+        break;
+    }
+
+    //// map out area for command list and FIS receive and data base address
+    // align on page so that there is no discontinuity in physical memory - size can't exceed one page
+    // cmdlist must be 1k aligned, and fis must be 256b aligned, cmdtbl must be 126b aligned
+    uint32_t size = HBA_CMDLIST_SIZE + FIS_REC_SIZE + sizeof(HBA_cmd_table_t) + SATA_BLOCK_SIZE;
+
+    // if its greater than a page, we have an issue
+    if (size > 0x1000) {
+        printke("Issue setting up sata device id: %d, memory space larger than a page", dev->id);
+        return;
+    }
+
+    void* cmdlist_base = kamalloc(size, 0x1000);
+    // mark page as cache disable
+    page_t *page = paging_get_page((uintptr_t)cmdlist_base, false, 0);
+    *page |= PAGE_CACHE_DISABLE;
+
+    // set command list base
+    uint32_t cmdlist_phys_base = (uint32_t)paging_virt_to_phys((uintptr_t)cmdlist_base);
+    port->clb = cmdlist_phys_base;
+    port->clbu = 0;
+
+    // set fis received base
+    port->fb = cmdlist_phys_base + HBA_CMDLIST_SIZE;
+    port->fbu = 0;
+
+    // check alignments
+    if(cmdlist_phys_base & 0b1111111111) {
+        printke("Issue setting up sata device id: %d, cmdlist not aligned", dev->id);
+        return;
+    }
+    if((cmdlist_phys_base+HBA_CMDLIST_SIZE) & 0b11111111) {
+        printke("Issue setting up sata device id: %d, fis receive not aligned", dev->id);
+        return;
+    }
+    if((cmdlist_phys_base+HBA_CMDLIST_SIZE+FIS_REC_SIZE) & 0b1111111) {
+        printke("Issue setting up sata device id: %d, cmdtbl not aligned", dev->id);
+        return;
+    }
+
+    //// zero out memory space and then appropriately fill the data structures
+    memset(cmdlist_base,0,size);
+
+    // cmd hdr
+    HBA_cmd_hdr_t* hdr = (HBA_cmd_hdr_t*)cmdlist_base;
+    hdr->prdtl = 1;
+    hdr->ctba = cmdlist_phys_base + (HBA_CMDLIST_SIZE + FIS_REC_SIZE);
+    hdr->ctbau = 0;
+
+    // prd
+    HBA_cmd_table_t* tbl = cmdlist_base + (HBA_CMDLIST_SIZE + FIS_REC_SIZE);
+    tbl->prdt_entry[0].dba = cmdlist_phys_base + (HBA_CMDLIST_SIZE + FIS_REC_SIZE + sizeof(HBA_cmd_table_t));
+    tbl->prdt_entry[0].dbau = 0;
+    tbl->prdt_entry[0].dbc = SATA_BLOCK_SIZE;
+
+    //// allow port to start running again
+    while (port->cmd & HBA_PORT_CMD_CR); // make sure port isn't running
+
+    port->cmd |= HBA_PORT_CMD_FRE; // indicate it can post to FIS
+    port->cmd |= HBA_PORT_CMD_ST;  // indicate to start processing command list
+
+
+
+    //// store virtual addresses in device struct
+    dev->cmdlist_base_virt = cmdlist_base;
+    dev->fis_rec_virt = cmdlist_base + (HBA_CMDLIST_SIZE);
+    dev->cmd_table_virt = cmdlist_base + (HBA_CMDLIST_SIZE + FIS_REC_SIZE);
+    dev->data_base_virt = cmdlist_base + (HBA_CMDLIST_SIZE + FIS_REC_SIZE + sizeof(HBA_cmd_table_t));
+}
+
+
+void sata_send_command(sata_device_t* dev) {
+    return;
+}
+
+
+// send identify device command
+void sata_identify_device(sata_device_t* dev) {
+    HBA_port_t* port = (dev->controller->base_address_virt + AHCI_PORTS_START_OFFSET + dev->port_num*AHCI_PORT_SIZE);
+
+    HBA_cmd_hdr_t* hdr = (HBA_cmd_hdr_t*)dev->cmdlist_base_virt;
+    HBA_cmd_table_t* tbl = dev->cmd_table_virt;
+
+    FIS_reg_h2d_t cmd = {0};
+    cmd.fis_type = FIS_TYPE_REG_H2D;
+    cmd.c = 1;
+    cmd.command = ATA_CMD_IDENTIFY_DEV;
+
+
+    memcpy(tbl,&cmd,sizeof(cmd));
+
+    port->ci = 0x01;
+
+    // spin for a second
+    for(int i = 0; i < 1000000; i++);
+
+
+    char* ptr = dev->data_base_virt;
+
+    printk("DEV IDENT response: ");
+    for(int i = 0; i < 512; i++) {
+        printk(" - %c",ptr[i]);
+    }
+
+    return;
+}
+
+void sata_read(sata_device_t* dev) {
+    return;
+}
+
+void sata_write(sata_device_t* dev) {
+    return;
+}
+
+void sata_read_device(sata_device_t* dev, uint32_t startl, uint32_t starth, uint32_t count, uint8_t *buf) {
+    //// send read command
+    // 
+    return;
+}

--- a/kernel/src/devices/sata.c
+++ b/kernel/src/devices/sata.c
@@ -172,7 +172,7 @@ bool sata_identify_device(sata_device_t* dev) {
     cmd.command = ATA_CMD_IDENTIFY_DEV;
 
     // move command to 
-    memcpy(tbl,&cmd,sizeof(cmd));
+    memcpy((void*)tbl,(const void*)&cmd,sizeof(cmd));
 
     // issue command
     port->ci = 0x01;
@@ -246,7 +246,7 @@ bool sata_read_device(sata_device_t* dev, uint32_t block_num_l, uint16_t block_n
     cmd.lba5 = (block_num_h >> 8) & 0xFF;
 
     // move command to table
-    memcpy(tbl,&cmd,sizeof(cmd));
+    memcpy((void*)tbl,(const void*)&cmd,sizeof(cmd));
 
     // issue command
     port->ci = 0x01;
@@ -297,7 +297,7 @@ bool sata_write_device(sata_device_t* dev, uint32_t block_num_l, uint16_t block_
     memcpy(dev->data_base_virt, buf, SATA_BLOCK_SIZE);
 
     // move command to table
-    memcpy(tbl,&cmd,sizeof(cmd));
+    memcpy((void*)tbl,(const void*)&cmd,sizeof(cmd));
 
     // issue command
     port->ci = 0x01;

--- a/kernel/src/kernel.c
+++ b/kernel/src/kernel.c
@@ -8,6 +8,7 @@
 #include <kernel/multiboot2.h>
 #include <kernel/paging.h>
 #include <kernel/pci.h>
+#include <kernel/ahci.h>
 #include <kernel/pmm.h>
 #include <kernel/proc.h>
 #include <kernel/ps2.h>
@@ -49,9 +50,11 @@ void kernel_main(mb2_t* boot, uint32_t magic) {
     init_idt();
     init_isr();
     init_irq();
-    init_pci();
-    init_syscall();
 
+    init_pci();
+    init_ahci();
+
+    init_syscall();
     init_ps2();
     init_timer();
 


### PR DESCRIPTION
Hey, 

I took a shot at adding basic AHCI+SATA support. Still needs a lot of work, it can only read and write one block at a time, and it's only within the kernel space. And only supports ATA requests, not ATAPI. 

Let me know if it works for you and what you think. I'd be happy to make adjustments based on your feedback and whatnot. Once I get it aligned with what you're looking for, I'm planning to add some more features as well and make it a bit robust. Maybe after that it can be integrated within the whole system so the root filesystem doesn't have to be baked into the GRUB image anymore. 

Also, need some guidance on allocating physical and virtual memory both contiguously that can be mapped to one another. See `ahci.c line 88` and `sata.c line 80`. I can elaborate a bit more if you'd like. 

Let me know what you think. 